### PR TITLE
Fix Discord Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
         <img src="https://img.shields.io/github/stars/Degen-dev/Degeneracy?style=for-the-badge" /></a>
     <a href="https://github.com/Degen-dev/Degeneracy/blob/master/LICENSE">
         <img src="https://img.shields.io/github/license/Degen-dev/Degeneracy?style=for-the-badge" /></a>
-    <a href="https://discord.gg/discord.gg/unblock">
+    <a href="https://discord.gg/unblock">
         <img src="https://img.shields.io/discord/419123358698045453?style=for-the-badge&logo=discord"
             alt="chat on Discord"></a>
 </p>


### PR DESCRIPTION
Discord Link won't work since it's typed wrong. Here is the fix since I noticed it.